### PR TITLE
ci: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,16 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
+
 jobs:
   semantic-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     outputs:
       release-version: ${{ steps.semantic.outputs.new_release_version }}
       new-release-published: ${{ steps.semantic.outputs.new_release_published }}
@@ -19,6 +26,8 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: semantic-release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Set version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Resolves the three CodeQL "Workflow does not contain permissions" (Medium) code-scanning alerts by adding explicit `GITHUB_TOKEN` permissions blocks to the workflows. Without an explicit block, the token defaults to broad, often write, scopes; declaring least-privilege permissions limits the blast radius if a step or action is compromised.

## Changes

**`.github/workflows/test.yml`**
- Add top-level `permissions: contents: read` — the workflow only builds and tests.

**`.github/workflows/release.yml`**
- Add top-level `permissions: contents: read` as a restrictive default.
- `semantic-release` job: `contents: write`, `issues: write`, `pull-requests: write` — needed to create tags/releases and comment on released issues/PRs.
- `docker` job: `contents: write` — needed to upload the plugin manifest/binaries to the GitHub release.

## Testing

- YAML edits only; no runtime code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNR2MRh1oEapRPADaTUrjC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNR2MRh1oEapRPADaTUrjC)_